### PR TITLE
Admins can sort products by open task count

### DIFF
--- a/app/assets/javascripts/components/admin/product_rankings.js.jsx
+++ b/app/assets/javascripts/components/admin/product_rankings.js.jsx
@@ -44,6 +44,7 @@
               <TableSortHeader width={150} onClick={this.handleSortToggled('created_at')} asc={this.sortOrder('created_at')} label="Created" />
               <TableSortHeader width={150} onClick={this.handleSortToggled('last_activity_at')} asc={this.sortOrder('last_activity_at')} label="Updated" />
               <TableSortHeader width={150} onClick={this.handleSortToggled('watchings_count')} asc={this.sortOrder('watchings_count')} label="Followers" align="right" />
+              <TableSortHeader width={150} onClick={this.handleSortToggled('open_tasks_count')} asc={this.sortOrder('open_tasks_count')} label="Open Tasks" align="right" />
               <TableSortHeader width={150} onClick={this.handleSortToggled('state')} asc={this.sortOrder('state')} label="State" />
               <TableSortHeader width={150} onClick={this.handleSortToggled('quality')} asc={this.sortOrder('quality')} label="Quality Score" align="right" />
             </tr>
@@ -161,6 +162,7 @@
         <td><Timestamp time={this.props.created} /></td>
         <td><Timestamp time={this.props.last_activity_at} /></td>
         <td className="text-right">{this.props.watchings_count}</td>
+        <td className="text-right">{this.props.open_tasks_count}</td>
         <td><ProductState state={this.state.state} url={'/admin/products/' + this.props.id} /></td>
         <td className="text-right">
           <input type="text" className="form-control" value={this.state.dirty ? this.state.pendingQualityScore : this.props.quality} style={{'background-color': bgColor}}

--- a/app/controllers/admin/product_rankings_controller.rb
+++ b/app/controllers/admin/product_rankings_controller.rb
@@ -1,6 +1,6 @@
 class Admin::ProductRankingsController < AdminController
   def index
-    @sort_column = Product.column_names.include?(params[:sort]) ? params[:sort] : "watchings_count"
+    @sort_column = (Product.column_names + ["open_tasks_count"]).include?(params[:sort]) ? params[:sort] : "watchings_count"
     @sort_direction = %w[asc desc].include?(params[:direction]) ? params[:direction].to_sym : :desc
     @showRanked = %w[true false].include?(params[:showranked]) ? params[:showranked] : 'false'
 
@@ -9,12 +9,18 @@ class Admin::ProductRankingsController < AdminController
       @products = @products.where("name ilike ?", "%#{query}%")
     end
 
-    @products = @products.
-      order("#{@sort_column} #{@sort_direction} NULLS LAST").
-      page(params[:page]).per(200)
-
     if @showRanked == 'false'
       @products = @products.where('quality is null')
+    end
+
+    if @sort_column == "open_tasks_count"
+      @products = @products.sort_by(&:open_tasks_count)
+      @products = @products.reverse if @sort_direction == :desc
+      @products = Kaminari.paginate_array(@products).page(params[:page]).per(200)
+    else
+      @products = @products.
+            order("#{@sort_column} #{@sort_direction} NULLS LAST").
+            page(params[:page]).per(200)
     end
 
     respond_to do |format|

--- a/app/serializers/product_ranking_serializer.rb
+++ b/app/serializers/product_ranking_serializer.rb
@@ -1,7 +1,7 @@
 class ProductRankingSerializer < ApplicationSerializer
 
   attributes :url
-  attributes :name, :pitch, :slug, :state, :quality, :watchings_count, :last_activity_at
+  attributes :name, :pitch, :slug, :state, :quality, :watchings_count, :last_activity_at, :open_tasks_count
 
   def url
     product_path(object)


### PR DESCRIPTION
- Modified @vanstee's React component to allow sorting by open task count

kind of ugly since `:open_tasks_count` is a calculated value...lmk if there are more elegant ways to implement this.
