### PR TITLE
Product responsiveness

### DIFF
--- a/app/models/product_metric.rb
+++ b/app/models/product_metric.rb
@@ -1,54 +1,157 @@
 class ProductMetric < ActiveRecord::Base
   belongs_to :product
 
+  serialize :response_times
+
+
+  # Metrics methods
+  def self.trailing_range_activity(product:, time: Time.now, range: 30.days)
+    Activity.where(product: product)
+            .where('created_at >= ?', time-range)
+            .where('created_at < ?', time)
+            .count
+  end
+
+  def self.response_times(product:, time: Time.now)
+
+    response_times = { "core" => [], "noncore" => [], "comments_count" => 0 }
+
+    # need to join on NFIs since comments are now attached to those
+    tasks_with_comments = product.tasks
+                                 .joins(:news_feed_items)
+                                 .where('news_feed_items.comments_count > 0')
+                                 .where('news_feed_items.updated_at <= ?', time)
+
+    if (ppms = ProductMetric.where(product: product).where('updated_at <= ?', time).order(created_at: :desc)).exists?
+      tasks_with_comments = tasks_with_comments.where('news_feed_items.updated_at > ?', ppms.first.created_at)
+    end
+
+    unless tasks_with_comments.blank?
+
+      tasks_with_comments.each do |t|
+        # ordered from least to most recent
+        comments = t.news_feed_item.comments.order(created_at: :asc).where('created_at <= ?', time)
+
+        if ppms.exists?
+          comments = comments.where('created_at > ?', ppms.first.created_at)
+        end
+
+        response_times["comments_count"] = comments.count
+        next if comments.count == 0
+
+        # add penalty to core for unanswered comments
+        # unless bounty is closed or last comment was from core
+        unless ["awarded", "closed", "resolved"].include?(t.state) || product.core_team.include?(comments.last.user)
+          response_times["core"] << (Time.now - comments.maximum(:created_at)).abs
+        end
+
+        if (product.core_team.include?(t.user) && !product.core_team.include?(comments.first.user))
+          response_times["noncore"] << comments.first.created_at - t.created_at
+        elsif (!product.core_team.include?(t.user) && product.core_team.include?(comments.first.user))
+          response_times["core"] << comments.first.created_at - t.created_at
+        end
+
+        next if comments.count == 1
+
+        comments.each do |c|
+          # time from comment to most recent previous comment
+          previous = t.news_feed_item.comments
+                                     .where('created_at < ?', c.created_at)
+                                     .where.not(id: c.id)
+                                     .reorder(created_at: :desc)
+                                     .limit(1)
+                                     .first
+
+          # unless no previous comment or current and previous comment are both made by core user
+          unless previous.nil? || (product.core_team.include?(c.user) && product.core_team.include?(previous.user))
+
+            # current comment made by core and previous is made by noncore
+            if product.core_team.include?(c.user) && !product.core_team.include?(previous.user)
+              times = response_times["core"]
+            else
+              times = response_times["noncore"]
+            end
+
+            time_diff = c.created_at - previous.created_at
+            times << time_diff unless time_diff <= 0
+          end
+        end
+      end
+    end
+    response_times.merge!(ppms.first.response_times){|k, x, y| x + y} if ppms.exists? && !ppms.first.response_times.nil?
+    response_times
+  end
+
+  def self.record_new(product:, time: Time.now)
+    response_times = response_times(product: product)
+    activity = trailing_range_activity(product: product, range: 30.days)
+
+    create(
+      product: product,
+      comments_count: response_times.delete("comments_count"){0},
+      noncore_responsiveness: response_times["noncore"].empty? ? -1 : response_times["noncore"].sum / response_times["noncore"].length,
+      core_responsiveness: response_times["core"].empty? ? -1 : response_times["core"].sum / response_times["core"].length,
+      response_times: response_times,
+      trailing_month_activity: activity,
+      created_at: time
+      )
+  end
+
+  # Math methods
+
   # note that queries exclude products that have no comments
 
   # weighted arithmetic mean comment responsiveness of all products
   # uses the most recent ProductMetric record
   # associated with each product
-  def self.mean_comment_responsiveness
-    sql = "select sum(product_metrics.comment_responsiveness * product_metrics.comments_count) / sum(product_metrics.comments_count) as average_comment_responsiveness FROM product_metrics where (product_id, created_at) in (select product_id, max(created_at)  from product_metrics group by product_id) AND comment_responsiveness > 0 AND comments_count > 0"
-    ActiveRecord::Base.connection.execute(sql).values.flatten.first.try(:to_f)
+  def self.overflow_safe_weighted_average(attr_name)
+    raise "that attribute name is invalid!" unless valid_numerical_attribute_type?(attr_name)
+
+    records = all_most_recent(attr_name).where('comments_count > 0')
+    denom = records.sum(:comments_count)
+
+    records.map{|x| x.public_send(attr_name).to_i * x.public_send(:comments_count).to_f / denom}.sum.to_i
   end
 
-  def self.overflow_safe_mean_comment_responsiveness
-    sql = "select product_metrics.* FROM product_metrics where (product_id, created_at) in (select product_id, max(created_at)  from product_metrics group by product_id) AND comment_responsiveness > 0 AND comments_count > 0"
-    results = ActiveRecord::Base.connection.exec_query(sql).to_hash
-    numerators = []
-    denominators = []
+  def self.calc_stddev(attr_name)
+    raise "that attribute name is invalid!" unless valid_numerical_attribute_type?(attr_name)
+    sql = "select stddev(product_metrics.#{attr_name}) as stddev_#{attr_name} FROM product_metrics where (product_id, created_at) in (select product_id, max(created_at) from product_metrics group by product_id) AND #{attr_name} > 0"
+    ActiveRecord::Base.connection.execute(sql).values.flatten.first.try(:to_i)
+  end
 
-    results.each do |r|
-      numerators << r["comment_responsiveness"].to_f * r["comments_count"].to_f
+  def self.calc_minimum(attr_name)
+    raise "that attribute name is invalid!" unless valid_numerical_attribute_type?(attr_name)
+    where("#{attr_name} > 0").minimum(attr_name)
+  end
+
+  def self.median(attr_name)
+    raise "that attribute name is invalid!" unless valid_numerical_attribute_type?(attr_name)
+    r = all_most_recent(attr_name).order(attr_name => :asc)
+    total = r.count
+    return "error" if total < 1
+    return r.first if total == 1
+
+    midpoint = total / 2
+
+    total % 2 == 0 ? (r.offset(midpoint-1).limit(2).pluck(attr_name).sum / 2.0) : r.offset(midpoint-1).limit(1).first.read_attribute(attr_name)
+  end
+
+  # only returns records where attr_name is positive
+  def self.all_most_recent(attr_name=nil)
+    raise "that attribute name is invalid!" unless valid_numerical_attribute_type?(attr_name)
+    clause = "(product_id, created_at) in (select product_id, max(created_at) from product_metrics group by product_id)"
+    query = where(clause)
+    attr_name.present? ? query.where("#{attr_name} > 0") : query
+  end
+
+  private
+
+    def self.get_attribute_type(attr_name)
+      columns_hash[attr_name.to_s].try(:type)
     end
 
-    denom = results.map{|x| x["comments_count"].to_f}.sum
-    results.map{|x| x["comment_responsiveness"].to_f * x["comments_count"].to_f / denom}.sum
-  end
-
-  def self.stddev_comment_responsiveness
-    sql = "select stddev(product_metrics.comment_responsiveness) as stddev_comment_responsiveness FROM product_metrics where (product_id, created_at) in (select product_id, max(created_at)  from product_metrics group by product_id) AND comment_responsiveness > 0"
-    ActiveRecord::Base.connection.execute(sql).values.flatten.first.try(:to_f)
-  end
-
-  def self.minimum_comment_responsiveness
-    ProductMetric.where('comment_responsiveness > 0').minimum(:comment_responsiveness)
-  end
-
-  def self.maximum_comment_responsiveness
-    ProductMetric.maximum(:comment_responsiveness)
-  end
-
-  def self.all_most_recent_comment_responsiveness
-    sql = "select * FROM product_metrics where (product_id, created_at) in (select product_id, max(created_at)  from product_metrics group by product_id) AND comment_responsiveness > 0"
-    ActiveRecord::Base.connection.exec_query(sql).to_hash
-  end
-
-  def self.median_comment_responsiveness
-    r = self.all_most_recent_comment_responsiveness
-    return "error" if r.length < 1
-    return r.first if r.length == 1
-    midpoint = r.length / 2
-    r.length % 2 == 0 ? (r[midpoint]["comment_responsiveness"].to_f + r[midpoint-1]["comment_responsiveness"].to_i) / 2 : r[midpoint]["comment_responsiveness"].to_f
-  end
+    def self.valid_numerical_attribute_type?(attr_name)
+      [:float, :integer].include? get_attribute_type(attr_name)
+    end
 
 end

--- a/app/models/product_stats.rb
+++ b/app/models/product_stats.rb
@@ -1,0 +1,12 @@
+class ProductStats
+  def self.top_products_by_activity(time: Time.now, range: 30.days, limit: 20)
+    Activity.joins(:product)
+            .group('products.slug')
+            .where('activities.created_at >= ?', time-range)
+            .where('activities.created_at < ?', time)
+            .count
+            .sort{|x, y| y[1] <=> x[1]}
+            .take(limit)
+  end
+end
+

--- a/db/migrate/20141223020714_breakdown_responsiveness_by_user_type.rb
+++ b/db/migrate/20141223020714_breakdown_responsiveness_by_user_type.rb
@@ -1,0 +1,5 @@
+class BreakdownResponsivenessByUserType < ActiveRecord::Migration
+  def change
+    add_column :product_metrics, :core_responsiveness, :float
+  end
+end

--- a/db/migrate/20141223231546_change_product_metric_columns.rb
+++ b/db/migrate/20141223231546_change_product_metric_columns.rb
@@ -1,0 +1,7 @@
+class ChangeProductMetricColumns < ActiveRecord::Migration
+  def change
+    remove_column :product_metrics, :comment_responsiveness
+    add_column :product_metrics, :noncore_responsiveness, :integer
+    add_column :product_metrics, :response_times, :text
+  end
+end

--- a/db/migrate/20141223235457_change_core_resp_column_type.rb
+++ b/db/migrate/20141223235457_change_core_resp_column_type.rb
@@ -1,0 +1,9 @@
+class ChangeCoreRespColumnType < ActiveRecord::Migration
+  def up
+    change_column :product_metrics, :core_responsiveness, :integer
+  end
+
+  def down
+    change_column :product_metrics, :core_responsiveness, :float
+  end
+end

--- a/db/migrate/20141224001651_fix_platform_metric_columns.rb
+++ b/db/migrate/20141224001651_fix_platform_metric_columns.rb
@@ -1,0 +1,10 @@
+class FixPlatformMetricColumns < ActiveRecord::Migration
+  def change
+    remove_column :platform_metrics, :mean_product_responsiveness
+    remove_column :platform_metrics, :median_product_responsiveness
+    add_column :platform_metrics, :mean_core_responsiveness, :integer
+    add_column :platform_metrics, :median_core_responsiveness, :integer
+    add_column :platform_metrics, :mean_noncore_responsiveness, :integer
+    add_column :platform_metrics, :median_noncore_responsiveness, :integer
+  end
+end

--- a/db/migrate/20141231171025_add_moving_avg_activity_to_product_metrics.rb
+++ b/db/migrate/20141231171025_add_moving_avg_activity_to_product_metrics.rb
@@ -1,0 +1,5 @@
+class AddMovingAvgActivityToProductMetrics < ActiveRecord::Migration
+  def change
+    add_column :product_metrics, :trailing_month_activity, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141223225045) do
+ActiveRecord::Schema.define(version: 20141231171025) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -503,11 +503,13 @@ ActiveRecord::Schema.define(version: 20141223225045) do
   end
 
   create_table "platform_metrics", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
-    t.float    "mean_product_responsiveness"
-    t.float    "median_product_responsiveness"
     t.datetime "calculated_at"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "mean_core_responsiveness"
+    t.integer  "median_core_responsiveness"
+    t.integer  "mean_noncore_responsiveness"
+    t.integer  "median_noncore_responsiveness"
   end
 
   create_table "posts", id: :uuid, force: :cascade do |t|
@@ -542,10 +544,13 @@ ActiveRecord::Schema.define(version: 20141223225045) do
 
   create_table "product_metrics", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
     t.uuid     "product_id"
-    t.integer  "comment_responsiveness"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "comments_count",         default: 0
+    t.integer  "comments_count",          default: 0
+    t.integer  "core_responsiveness"
+    t.integer  "noncore_responsiveness"
+    t.text     "response_times"
+    t.integer  "trailing_month_activity"
   end
 
   add_index "product_metrics", ["product_id"], name: "index_product_metrics_on_product_id", using: :btree

--- a/lib/tasks/platform_metrics.rake
+++ b/lib/tasks/platform_metrics.rake
@@ -1,13 +1,45 @@
 namespace :platform_metrics do
-  desc "Calculates and stores comment responsiveness"
-  task :calculate_comment_responsiveness => :environment do
-    # calculates commment response time for each product
+  desc "Calculates and stores product responsiveness"
+  task :calculate_product_responsiveness => :environment do
+    # calculates responsiveness for each product
     # this creates a new ProductMetric record for each product
-    Product.all.map(&:calc_task_comments_response_time)
+    Product.all.each do |p|
+      ProductMetric.record_new(product: p)
+    end
+
     PlatformMetric.create(
-      mean_product_responsiveness: ProductMetric.overflow_safe_mean_comment_responsiveness,
-      median_product_responsiveness: ProductMetric.median_comment_responsiveness,
+      mean_core_responsiveness: ProductMetric.overflow_safe_weighted_average(:core_responsiveness),
+      median_core_responsiveness: ProductMetric.median(:core_responsiveness),
+      mean_noncore_responsiveness: ProductMetric.overflow_safe_weighted_average(:noncore_responsiveness),
+      median_noncore_responsiveness: ProductMetric.median(:noncore_responsiveness),
       calculated_at: Time.now
     )
+  end
+
+  task :historical_responsiveness => :environment do
+
+    old_level = ActiveRecord::Base.logger.level
+    ActiveRecord::Base.logger.level = 2 # don't log debug or info
+
+    ending = Time.now
+    start = Time.now - 2.months
+
+    while((start += 1.day) < ending)
+      products = Product.where('created_at < ?', start)
+      puts "#{start.strftime('%m %d %Y')} - #{products.count} products \n\n"
+      products.each_with_index do |p, index|
+        puts "#{p.slug} - #{((index+1)*100/products.count.to_f).round(2)}%"
+        ProductMetric.record_new(product: p, time: start)
+      end
+
+      PlatformMetric.create(
+        mean_core_responsiveness: ProductMetric.overflow_safe_weighted_average(:core_responsiveness),
+        median_core_responsiveness: ProductMetric.median(:core_responsiveness),
+        mean_noncore_responsiveness: ProductMetric.overflow_safe_weighted_average(:noncore_responsiveness),
+        median_noncore_responsiveness: ProductMetric.median(:noncore_responsiveness),
+        calculated_at: start
+      )
+    end
+    ActiveRecord::Base.logger.level = old_level
   end
 end

--- a/spec/models/product_metric_spec.rb
+++ b/spec/models/product_metric_spec.rb
@@ -1,43 +1,132 @@
 require 'spec_helper'
 
 describe ProductMetric do
-  let!(:product) { Product.make! }
-  let!(:product_two) { Product.make! }
-  let!(:task) { Task.make!(product: product) }
-  let!(:task_two) { Task.make!(product: product_two) }
-  let!(:user) { User.make!(username: 'userzero') }
-  # # response to task in 10 seconds
-  let!(:comment_one) { task.comments.create!(user: user, body: "comment", created_at: task.created_at + 10) }
-  # # response to comment two in 40 seconds
-  let!(:comment_two) { task.comments.create!(user: user, body: "comment", created_at: comment_one.created_at + 40) }
-  let!(:comment_three) { task_two.comments.create!(user: user, body: "comment", created_at: task_two.created_at + 100) }
 
   before(:each) do
-    Product.all.map(&:calc_task_comments_response_time)
+    product_one = Product.make!
+    product_two = Product.make!
+    noncore_user = User.make!(username: 'noncoreuser')
+    core_user = User.make!(username: 'coreuser')
+
+    product_one.core_team += [core_user]
+    product_two.core_team += [core_user]
+
+    # task one (core)
+    # - noncore
+    # - core
+    # - core
+    # - noncore
+    # core responsiveness: 10 + penalty for unanswered noncore comment
+    # noncore reponsiveness: (10+20)/2 = 15
+    task_one_one = Task.make!(product: product_one, user: core_user)
+    nfi_one_one = NewsFeedItem.create_with_target(task_one_one)
+    nfi_one_one.comments.create!(user: noncore_user, body: "product one task one comment one", created_at: task_one_one.created_at + 10.seconds)
+    nfi_one_one.comments.create!(user: core_user, body: "product one task one comment two", created_at: task_one_one.created_at + 20.seconds)
+    nfi_one_one.comments.create!(user: core_user, body: "product one task one comment three", created_at: task_one_one.created_at + 30.seconds)
+    @penalized_comment = nfi_one_one.comments.create!(user: noncore_user, body: "product one task one comment four", created_at: task_one_one.created_at + 50.seconds)
+
+    # task two (noncore)
+    # - core
+    # - core
+    # core responsiveness: 60
+    # noncore responsiveness: n/a
+    task_one_two = Task.make!(product: product_one, user: noncore_user)
+    nfi_one_two = NewsFeedItem.create_with_target(task_one_two)
+    nfi_one_two.comments.create!(user: core_user, body: "product one task two comment one", created_at: task_one_two.created_at + 60.seconds)
+    nfi_one_two.comments.create!(user: core_user, body: "product one task two comment two", created_at: task_one_two.created_at + 70.seconds)
+
+    # task three (core) [closed]
+    # - noncore
+    # core responsiveness: n/a
+    # noncore responsiveness: 70
+    task_two_one = Task.make!(product: product_two, user: core_user, state: "closed")
+    nfi_two_one = NewsFeedItem.create_with_target(task_two_one)
+    nfi_two_one.comments.create!(user: noncore_user, body: "product two task one comment one", created_at: task_two_one.created_at + 70.seconds)
+
+    # task four (core)
+    # - noncore
+    # - core
+    # core responsiveness: 80
+    # noncore responsiveness: 20
+    task_two_two = Task.make!(product: product_two, user: core_user)
+    nfi_two_two = NewsFeedItem.create_with_target(task_two_two)
+    nfi_two_two.comments.create!(user: noncore_user, body: "product two task two comment one", created_at: task_two_two.created_at + 20.seconds)
+    nfi_two_two.comments.create!(user: core_user, body: "product two task two comment two", created_at: task_two_two.created_at + 100.seconds)
+
+    # product one
+    # - core: (10+60+created_at_to_time_now)/3 = >70+1 day
+    # - noncore: (10+20)/2 = 15
+    # product two
+    # - core: 80
+    # - noncore: (20+70)/2
+    Timecop.freeze(Time.now+1.day) do
+      @timenow = Time.now
+      Product.all.each do |p|
+        ProductMetric.record_new(product: p)
+      end
+    end
+
+    @first_prod_metric = ProductMetric.first
+    @second_prod_metric = ProductMetric.last
   end
 
+  # TODO: refactor so each Task/NFI can calculate its own responsiveness
+  # and test each Task/NFI
   describe "comment responsiveness" do
-    it 'returns the correct minimum_average_comment_responsiveness' do
-      min = ProductMetric.minimum_comment_responsiveness
+    # min
+    it 'returns the correct minimum_core_comment_responsiveness' do
+      min = ProductMetric.calc_minimum(:core_responsiveness)
+
+      expect(min).to eq(80)
+    end
+    it 'returns the correct minimum_non_core_comment_responsiveness' do
+      min = ProductMetric.calc_minimum(:noncore_responsiveness)
+
       expect(ProductMetric.count).to eq(2)
-      expect(min).to eq(50)
+      expect(min).to eq(15)
     end
-    it 'returns the correct maximum_average_comment_responsiveness' do
-      max = ProductMetric.maximum_comment_responsiveness
-      expect(max).to eq(100)
+
+    # max
+    it 'returns the correct maximum_core_comment_responsiveness' do
+      max = ProductMetric.maximum(:core_responsiveness)
+
+      expect(max).to eq((10+60+(@timenow-@penalized_comment.created_at).abs.to_i)/3)
     end
-    it 'returns the correct weighted average comment_responsiveness on all products' do
-      mean = ProductMetric.mean_comment_responsiveness
-      expect(mean).to eq(((50*2)+ 100)/3)
+    it 'returns the correct maximum_non_core_comment_responsiveness' do
+      max = ProductMetric.maximum(:noncore_responsiveness)
+
+      expect(max).to eq((20+70)/2)
     end
-    it 'returns the same value for overflow_safe and sql methods' do
-      mean = ProductMetric.mean_comment_responsiveness
-      overflow_safe_mean = ProductMetric.overflow_safe_mean_comment_responsiveness
-      expect(mean.floor).to eq(overflow_safe_mean.floor)
+
+    # weighted averages
+    it 'returns the correct weighted core average comment_responsiveness on all products' do
+      mean = ProductMetric.overflow_safe_weighted_average(:core_responsiveness)
+
+      expected = (@first_prod_metric.core_responsiveness * @first_prod_metric.comments_count + @second_prod_metric.core_responsiveness * @second_prod_metric.comments_count) / ProductMetric.sum(:comments_count)
+
+      expect(mean).to eq(expected)
     end
-    it 'returns the correct median_comment_responsiveness on all products' do
-      median = ProductMetric.median_comment_responsiveness
-      expect(median).to eq((100+50)/2)
+    it 'returns the correct weighted non_core average comment_responsiveness on all products' do
+      mean = ProductMetric.overflow_safe_weighted_average(:noncore_responsiveness)
+
+      expected = (@first_prod_metric.noncore_responsiveness * @first_prod_metric.comments_count + @second_prod_metric.noncore_responsiveness * @second_prod_metric.comments_count) / ProductMetric.sum(:comments_count)
+
+      expect(mean).to eq(expected)
+    end
+
+    # median
+    it 'returns the correct core median_comment_responsiveness on all products' do
+      median = ProductMetric.median(:core_responsiveness)
+
+      expected = (@first_prod_metric.core_responsiveness + @second_prod_metric.core_responsiveness) / 2.0
+
+      expect(median).to eq(expected)
+    end
+    it 'returns the correct non_core median_comment_responsiveness on all products' do
+      median = ProductMetric.median(:noncore_responsiveness)
+      expected = (@first_prod_metric.noncore_responsiveness + @second_prod_metric.noncore_responsiveness) / 2.0
+
+      expect(median).to eq(expected)
     end
   end
 end


### PR DESCRIPTION
- Move logic from `Product` to `ProductMetric`
- Break out responsiveness into core and noncore
- Add trailing 30 day activity count to `ProductMetric`
