### PR TITLE
Mark products with language in repos

### DIFF
--- a/lib/tasks/products.rake
+++ b/lib/tasks/products.rake
@@ -36,7 +36,10 @@ namespace :products do
       languages.each do |k, v|
         marks << k if v/total_lines.to_f > THRESHOLD
       end
-      puts "would mark #{p.slug} with #{marks}"
+
+      marks.each do |m|
+        MakeMarks.new.mark_with_name(p, m)
+      end
     end
   end
 end


### PR DESCRIPTION
This rake task will mark products with the languages in their respective repos.

We can set a threshold value to help increase relevance.  10% is chosen as an initial value based on the expected result of [Dreiser](https://github.com/asm-products/dreiser) being marked with Clojure.  We can potentially bump this, but it could mean a loss in detail.

Results with a 10% threshold:

```
launchpad: ["JavaScript", "CSS"]
calmail: ["Ruby"]
secretary: ["Assembly"]
dreiser: ["JavaScript", "Clojure"]
talenge: ["Python"]
evergist: ["JavaScript"]
good-h: with ["Objective-C"]
firesize: ["Go", "JavaScript", "CSS"]
gig-: with ["Objective-C", "Java"]
villeme: ["Ruby", "CoffeeScript", "CSS"]
banyan: ["Python", "JavaScript", "Objective-C"]
ripple: ["JavaScript", "Objective-C"]
confy: ["JavaScript"]
visitmee: ["JavaScript"]
wait-k: with ["Ruby"]
splitty: ["CSS", "JavaScript"]
unsqu: with ["Python", "JavaScript"]
barrtr: ["CSS", "JavaScript"]
boost: ["JavaScript"]
localhost: ["Java"]
simplewiki: ["Ruby", "CSS"]
instascope: ["Objective-C"]
cryptopals: ["Python"]
gridspree: ["CSS", "JavaScript"]
movie-dat: with ["Python"]
invoicing: ["PHP"]
bootsnap: ["Ruby"]
pollanation: ["Ruby"]
prathamalag1994-ba: with ["Ruby", "CSS"]
zcast: ["JavaScript"]
backboard: ["JavaScript"]
icycling: ["Objective-C"]
coderwall: ["Ruby", "JavaScript", "CSS"]
formspree: ["Python", "CSS"]
grpzi: ["JavaScript"]
pageweb: ["PHP", "CSS", "JavaScript"]
gamamia: ["Ruby"]
write-: with ["Ruby"]
music: with ["JavaScript", "CSS"]
wivern: ["Ruby", "CSS"]
signupsumo: ["Ruby"]
positive-: with ["Ruby", "CSS"]
happycompany: ["Ruby", "CSS"]
buckets: ["CoffeeScript", "CSS"]
simply-classi: with ["PHP"]
nested-commun: with ["Python"]
cliq: ["Ruby", "CSS"]
automated: ["Swift"]
voices: ["Swift", "Objective-C"]
zenforms: ["Ruby", "CSS"]
oovre: ["Ruby", "JavaScript", "CSS"]
croud: ["JavaScript", "CSS"]
payzo: ["Ruby", "CSS"]
octobox: ["JavaScript", "CSS"]
spaceship-: with ["Python"]
peanut-b:-jams with ["JavaScript"]
badger: ["Clojure"]
idealist: ["PHP", "CSS", "JavaScript"]
amass: ["Ruby"]
invoicerio: ["Ruby", "CSS"]
giraff: ["Objective-C", "Shell", "Java"]
totroops: ["Python", "CSS"]
saulify: ["Python", "CSS", "JavaScript"]
hashtag-we: with ["Ruby"]
collectormetric: ["Ruby", "CSS"]
payments: ["JavaScript", "CSS"]
settr: []
mana: ["Ruby"]
runbook: ["Python", "Perl"]
gathercam: ["Ruby", "CSS"]
chartspree: ["CSS"]
kanshu: ["CSS", "JavaScript"]
hesperides: ["Ruby"]
copibay: ["CSS", "JavaScript"]
silent-butt: with ["JavaScript", "CSS"]
coffee: with ["Ruby"]
ca: with ["Ruby", "Shell"]
atlas: ["Java"]
meta: ["Ruby", "JavaScript", "CSS"]
music: with ["CSS", "JavaScript"]
geekapes: ["PHP", "CSS"]
sim: ["JavaScript", "CSS"]
helpful: ["Ruby", "JavaScript", "CSS", "Objective-C"]
hn-mo: with ["Ruby", "JavaScript"]
nomad: ["Ruby", "Swift", "Objective-C", "Java"]
closery: ["JavaScript"]
calenssist: ["Python"]
bettrhuman: ["JavaScript", "CSS"]
the-newsr: with ["C#"]
flash: with ["JavaScript"]
prudio: ["JavaScript", "CSS"]
meowboard: ["Swift"]
boxychat: ["JavaScript", "CSS"]
zipifieds: ["Ruby", "JavaScript"]
leasepop: ["PHP"]
sheetsh: ["CoffeeScript"]
pretty-: with ["JavaScript"]
bananner: ["Ruby"]
monocle: ["Objective-C"]
pvtcard: ["JavaScript"]
lancr: ["Ruby", "JavaScript"]
readraptor: ["CSS", "Go", "JavaScript"]
capoeira-l: with ["CSS"]
instadeck: ["JavaScript"]
localert: ["Objective-C"]
pine: ["CSS"]
assemblycoins: ["Python"]
monsoon: ["Clojure", "JavaScript"]
really:-emails with ["JavaScript", "CSS", "PHP"]
artfactum: ["Ruby", "JavaScript"]
```
