### PR TITLE
fixed broken/mistyped links on help/guide pages

### DIFF
--- a/app/views/faq_groups/building.md
+++ b/app/views/faq_groups/building.md
@@ -60,4 +60,4 @@ If a necessary bounty goes uncompleted, Assembly may be able to help. We're equi
 
 # What happens if development stops on an app?
 
-If an idea doesn't get and/or sustain support Assembly may decide to retire it. We'll notify the inventor and all the contributors. Assembly may also change the source code license to the MIT license and all non-code contributed work will be released under the [Creative Commons Attribution Non-Commercial 3.0 Unported License](http://www.google.com/url?q=http%3A%2F%2Fcreativecommons.org%2Flicenses%2Fby-nc%2F3.0%2Fus%2F&sa=D&sntz=1&usg=AFQjCNGD0KjEha9wLevv3yo3xo6SQsKLXw).
+If an idea doesn't get and/or sustain support Assembly may decide to retire it. We'll notify the inventor and all the contributors. Assembly may also change the source code license to the MIT license and all non-code contributed work will be released under the [Creative Commons Attribution Non-Commercial 3.0 Unported License](http://creativecommons.org/licenses/by-nc/3.0/us/).

--- a/app/views/faq_groups/launching.md
+++ b/app/views/faq_groups/launching.md
@@ -1,6 +1,6 @@
 # How do I submit an app idea?
 
-If you have a great idea for an app to build on Assembly, head over [here](assembly.com/start).
+If you have a great idea for an app to build on Assembly, head over [here](http://assembly.com/start).
 
 
 # Who will build my app if I submit an idea?

--- a/app/views/faq_groups/platform.md
+++ b/app/views/faq_groups/platform.md
@@ -15,7 +15,7 @@ However, only the Core Team can award a bounty.
 
 # Where can I request features for Assembly?
 
-You can [submit a bounty](/meta/wips), or you can [hop into general chat](www.assembly.com/chat/general) and let us know.
+You can [submit a bounty](/meta/wips), or you can [hop into general chat](/chat/general) and let us know.
 
 
 # How can I change my account settings?

--- a/app/views/guides_groups/platform.md
+++ b/app/views/guides_groups/platform.md
@@ -118,10 +118,10 @@ count towards profit disbursements and product management decisions.
 Bounties are tasks directly involved with the development of a product.  They
 are designed by participants to advertise specific product needs.  Anyone may
 work on a bounty.  Bounties are the primary way for new users, who have no <a
-href="/guides/project-management#managing-ownership">ownership</a> in a
+href="/guides/product-management#managing-ownership">ownership</a> in a
 product, to earn their first stake in the product.
 
-Bounties are <a href="/guides/project-management#valuing-bounties">priced in
+Bounties are <a href="/guides/product-management#valuing-bounties">priced in
 App Coins</a>, which are the units of ownership of a given product.  These
 coins are awarded to users who have completed the bounty.  Bounties are awarded
 to users by <a href="#core-team">Core Team</a> members.


### PR DESCRIPTION
`app/views/faq_groups/building.md`
The link doesn't have to go through a google search :)

`app/views/faq_groups/launching.md`
fixed link the final link showing was https://assembly.com/help/assembly.com/start which result in 404

`app/views/faq_groups/platform.md`
fixed link the final link showing was https://assembly.com/help/www.assembly.com/chat/general which result in 404

`app/views/guides_groups/platform.md`
fixed typos in 2 links