### PR TITLE
Fix broken link in user profile

### DIFF
--- a/app/assets/javascripts/components/user/profile_bounties_awarded.js.jsx
+++ b/app/assets/javascripts/components/user/profile_bounties_awarded.js.jsx
@@ -77,7 +77,7 @@ module.exports = React.createClass({
     if (this.props.user_id == UserStore.getUsername()) {
       return <div className="m4 p3 bg-gray-6 center">
         Get involved in <a href="/discover">products</a>, complete bounties and you&#39;ll
-        earn yourself app coins. App coins represent your ownership in products. <a href="/help/profits#profits-2">Learn more in the FAQ</a>
+        earn yourself app coins. App coins represent your ownership in products. <a href="/help/revenue">Learn more in the FAQ</a>
       </div>
     }
     return <div />


### PR DESCRIPTION
A link with content "Learn more in the FAQ" which appears on the user's profile page for new users who don't yet have any app coins is linked to a URL which no longer exists. 

Update it to reference the appropriate section of the FAQ. 